### PR TITLE
Improved parsing of PHP version from PHPCompatibility messages.

### DIFF
--- a/src/XWP/Bundle/AuditServerBundle/Extensions/Audits/PhpCsAuditManager.php
+++ b/src/XWP/Bundle/AuditServerBundle/Extensions/Audits/PhpCsAuditManager.php
@@ -465,14 +465,14 @@ class PhpCsAuditManager extends BaseManager
                     if (preg_match('/(?:PHP|PHP version|PHP <|since) (\d(?:\.\d)*)/i', $message['message'], $match)) {
                         // Should match all known PHPCompatibility output messages that include the PHP version.
                         $php_version = $match[1];
-                    } else if(preg_match('/\d(?:\.\d)+/', $message['message'], $match)) {
+                    } elseif (preg_match('/\d(?:\.\d)+/', $message['message'], $match)) {
                         // Grasping at straws in case something slips through. To prevent from matching on any number,
                         // this pattern matches only Major.Minor and Major.Minor.Release and not just Major.
                         $php_version = $match['0'];
                     } else {
                         $php_version = 'general';
                     }
-                    if (false === strpos($php_version, '.')) {
+                    if (false === strpos($php_version, '.') && 'general' !== $php_version) {
                         // Add sane minor version numbers if only a major version was found.
                         if ('5' === $php_version) {
                             $php_version = '5.2';


### PR DESCRIPTION
In running tests, I found issues with the PHP version being properly parsed out of the PHPCompatibility message. For instance, this message in particular shows how the greedy regex led to improper version detection:

`The constant "ENT_HTML401" is not present in PHP version 5.3 or earlier`

This change includes more explicit regex rules created by inspecting the PHPCompatibility source and making a list of formats used to indicate the PHP version in the message. The original code had a wide net test to try to catch versions. I kept that wide net test but moved it to a fallback and tightened it up a bit so that it only matches Major.Minor.Release or Major.Minor versions.